### PR TITLE
chore: bump npm dependencies in server/

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pause": {


### PR DESCRIPTION
## Summary
Resolves all 3 open Dependabot alerts on the **server/** side via `npm audit fix` (no `--force`, only non-breaking bumps within existing caret ranges). Lockfile-only diff.

After: `npm audit` in `server/` reports **0 vulnerabilities**.

## ⚠️ client/ side not addressed in this PR
The client/ side has 8 high-severity Angular advisories that need a deliberate Angular minor bump (19.2.x → 19.2.21+). However, **the client side already fails `npm install` on master** with an `ERESOLVE` peer-dep conflict between `@angular-devkit/build-angular@19.2.25` and the current Angular pins. So this is a pre-existing issue, not a regression from this PR.

Recommend handling client/ as a follow-up:
1. Pin `@angular-devkit/build-angular` to a version compatible with the current `@angular/*` set, or
2. Bump everything to a clean Angular 19.2.21+ matrix using the official `ng update` workflow.

## Test plan
- [ ] `cd server && npm install` resolves cleanly
- [ ] `cd server && npm run dev` starts without errors
- [ ] No regression in API behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)